### PR TITLE
Build Exec ShortAnswer Refactoring

### DIFF
--- a/packages/core/src/amazonqTest/chat/controller/controller.ts
+++ b/packages/core/src/amazonqTest/chat/controller/controller.ts
@@ -1115,9 +1115,6 @@ export class TestController {
     }
 
     private async checkForInstallationDependencies(data: any) {
-        // const session: Session = this.sessionStorage.getSession()
-        // const listOfInstallationDependencies = session.testGenerationJob?.shortAnswer?.installationDependencies || []
-        // MOCK: As there is no installation dependencies in shortAnswer
         const listOfInstallationDependencies = ['']
         const installationDependencies = listOfInstallationDependencies.join('\n')
 
@@ -1481,7 +1478,6 @@ export class TestController {
         session.testGenerationJobGroupName = undefined
         // session.testGenerationJob = undefined
         session.updatedBuildCommands = undefined
-        session.shortAnswer = undefined
         session.testCoveragePercentage = 0
         session.conversationState = ConversationState.IDLE
         session.sourceFilePath = ''
@@ -1526,8 +1522,8 @@ export class TestController {
             return [...session.updatedBuildCommands]
         }
 
-        if (session.shortAnswer && session.shortAnswer?.buildCommand) {
-            return [session.shortAnswer.buildCommand]
+        if (session.packageInfo && session.packageInfo?.buildCommand) {
+            return [session.packageInfo.buildCommand]
         }
         // TODO: Add a generic command here for external launch according to the build system.
         return ['brazil-build release']

--- a/packages/core/src/amazonqTest/chat/session/session.ts
+++ b/packages/core/src/amazonqTest/chat/session/session.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ShortAnswer, Reference } from '../../../codewhisperer/models/model'
-import { TargetFileInfo, TestGenerationJob } from '../../../codewhisperer/client/codewhispereruserclient'
+import { Reference } from '../../../codewhisperer/models/model'
+import { PackageInfo, TargetFileInfo, TestGenerationJob } from '../../../codewhisperer/client/codewhispereruserclient'
 
 export enum ConversationState {
     IDLE,
@@ -37,13 +37,13 @@ export class Session {
     // Start Test generation
     public isSupportedLanguage: boolean = false
     public conversationState: ConversationState = ConversationState.IDLE
-    public shortAnswer: ShortAnswer | undefined
     public sourceFilePath: string = ''
     public generatedFilePath: string = ''
     public projectRootPath: string = ''
     public fileLanguage: string | undefined = 'plaintext'
     public stopIteration: boolean = false
     public targetFileInfo: TargetFileInfo | undefined
+    public packageInfo: PackageInfo | undefined
     public jobSummary: string = ''
 
     // Telemetry

--- a/packages/core/src/codewhisperer/commands/startTestGeneration.ts
+++ b/packages/core/src/codewhisperer/commands/startTestGeneration.ts
@@ -54,7 +54,6 @@ export async function startTestGenerationProcess(
             const projectPath = zipUtil.getProjectPath(filePath) ?? ''
             const relativeTargetPath = path.relative(projectPath, filePath)
             session.listOfTestGenerationJobId = []
-            session.shortAnswer = undefined
             session.sourceFilePath = relativeTargetPath
             session.projectRootPath = projectPath
             session.listOfTestGenerationJobId = []

--- a/packages/core/src/codewhisperer/models/model.ts
+++ b/packages/core/src/codewhisperer/models/model.ts
@@ -1174,18 +1174,3 @@ export interface Reference {
         end: number
     }
 }
-
-// TODO: remove ShortAnswer because it will be deprecated
-export interface ShortAnswer {
-    testFilePath: string
-    buildCommand: string
-    planSummary: string
-    sourceFilePath?: string
-    testFramework?: string
-    executionCommands?: string[]
-    testCoverage?: number
-    stopIteration?: string
-    errorMessage?: string
-    codeReferences?: References
-    numberOfTestMethods?: number
-}

--- a/packages/core/src/codewhisperer/service/testGenHandler.ts
+++ b/packages/core/src/codewhisperer/service/testGenHandler.ts
@@ -22,7 +22,7 @@ import {
     TestGenTimedOutError,
 } from '../../amazonqTest/error'
 import { getMd5, uploadArtifactToS3 } from './securityScanHandler'
-import { ShortAnswer, testGenState, Reference } from '../models/model'
+import { testGenState, Reference } from '../models/model'
 import { ChatSessionManager } from '../../amazonqTest/chat/storages/chatSession'
 import { createCodeWhispererChatStreamingClient } from '../../shared/clients/codewhispererChatClient'
 import { downloadExportResultArchive } from '../../shared/utilities/download'
@@ -159,12 +159,6 @@ export async function pollTestJobStatus(
             })
         }
 
-        const shortAnswerString = resp.testGenerationJob?.shortAnswer
-        if (shortAnswerString) {
-            const parsedShortAnswer = JSON.parse(shortAnswerString)
-            const shortAnswer: ShortAnswer = JSON.parse(parsedShortAnswer)
-        }
-
         const jobSummary = resp.testGenerationJob?.jobSummary ?? ''
         const jobSummaryNoBackticks = jobSummary.replace(/^`+|`+$/g, '')
         ChatSessionManager.Instance.getSession().jobSummary = jobSummaryNoBackticks
@@ -173,7 +167,8 @@ export async function pollTestJobStatus(
         const targetFileInfo = packageInfo?.targetFileInfoList?.[0]
 
         if (packageInfo) {
-            // TODO: will need some fields from packageInfo such as buildCommand, packagePlan, packageSummary
+            // TODO: will use some fields from packageInfo in the future
+            ChatSessionManager.Instance.getSession().packageInfo = packageInfo
         }
         if (targetFileInfo) {
             if (targetFileInfo.numberOfTestMethods) {


### PR DESCRIPTION
Removing shortAnswer in Build exec to use the new fields from API refactoring

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
