### PR TITLE
fix(chat): remove shell command header buttons with status after clic…

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -345,12 +345,22 @@ export class Connector extends BaseConnector {
                 }
                 break
             case 'run-shell-command':
-                if (answer.header) {
-                    answer.header.status = {
+                if (Object.keys(answer.header!).length === 0) {
+                    answer.header = {
+                        body: '$ shell',
+                        status: {
+                            icon: 'ok' as MynahIconsType,
+                            text: 'Accepted',
+                            status: 'success',
+                        },
+                    }
+                } else {
+                    answer.header!.status = {
                         icon: 'ok' as MynahIconsType,
                         text: 'Accepted',
                         status: 'success',
                     }
+                    answer.header!.buttons = []
                 }
                 break
             case 'reject-shell-command':
@@ -360,6 +370,7 @@ export class Connector extends BaseConnector {
                         text: 'Rejected',
                         status: 'error',
                     }
+                    answer.header.buttons = []
                 }
                 break
             default:

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -475,13 +475,12 @@ export class Messenger {
             }
 
             shellCommandHeader = {
-                icon: 'code-block' as MynahIconsType,
-                body: 'shell',
+                body: '$ shell',
                 buttons: buttons,
             }
 
             if (validation.warning) {
-                message = validation.warning + message
+                message = validation.warning + message + '\nRun the command to proceed.\n'
             }
         } else if (toolUse?.name === ToolType.FsWrite) {
             const input = toolUse.input as unknown as FsWriteParams


### PR DESCRIPTION
…k run or reject

## Problem
- remove shell command header buttons with status after click run or reject

## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
