### PR TITLE
feat(chat): Add user validation for tools

### DIFF
--- a/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
+++ b/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts
@@ -314,10 +314,14 @@ export class Connector extends BaseConnector {
 
         if (
             !this.onChatAnswerUpdated ||
-            !(
-                ['accept-code-diff', 'run-shell-command', 'reject-shell-command'].includes(action.id) ||
-                action.id.startsWith('reject-code-diff')
-            )
+            ![
+                'accept-code-diff',
+                'reject-code-diff',
+                'run-shell-command',
+                'reject-shell-command',
+                'confirm-tool-use',
+                'reject-tool-use',
+            ].includes(action.id)
         ) {
             return
         }
@@ -372,6 +376,30 @@ export class Connector extends BaseConnector {
                     }
                     answer.header.buttons = []
                 }
+                break
+            case 'confirm-tool-use':
+                answer.buttons = [
+                    {
+                        keepCardAfterClick: true,
+                        text: 'Confirmed',
+                        id: 'confirmed-tool-use',
+                        status: 'success',
+                        position: 'outside',
+                        disabled: true,
+                    },
+                ]
+                break
+            case 'reject-tool-use':
+                answer.buttons = [
+                    {
+                        keepCardAfterClick: true,
+                        text: 'Rejected',
+                        id: 'rejected-tool-use',
+                        status: 'error',
+                        position: 'outside',
+                        disabled: true,
+                    },
+                ]
                 break
             default:
                 break

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -849,8 +849,13 @@ export class ChatController {
                 await this.handleCreatePrompt(message)
                 break
             case 'run-shell-command':
+            case 'confirm-tool-use':
             case 'generic-tool-execution':
                 await this.processToolUseMessage(message)
+                break
+            case 'reject-code-diff':
+            case 'reject-tool-use':
+                await this.closeDiffView()
                 break
             case 'reject-shell-command':
                 await this.rejectShellCommand(message)

--- a/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/messenger/messenger.ts
@@ -482,6 +482,17 @@ export class Messenger {
             if (validation.warning) {
                 message = validation.warning + message + '\nRun the command to proceed.\n'
             }
+        } else if (validation.requiresAcceptance) {
+            buttons.push({
+                id: 'reject-tool-use',
+                text: 'Reject',
+                status: 'info',
+            })
+            buttons.push({
+                id: 'confirm-tool-use',
+                text: 'Confirm',
+                status: 'info',
+            })
         } else if (toolUse?.name === ToolType.FsWrite) {
             const input = toolUse.input as unknown as FsWriteParams
             const fileName = path.basename(input.path)

--- a/packages/core/src/codewhispererChat/tools/executeBash.ts
+++ b/packages/core/src/codewhispererChat/tools/executeBash.ts
@@ -9,6 +9,9 @@ import { fs } from '../../shared/fs/fs'
 import { ChildProcess, ChildProcessOptions } from '../../shared/utilities/processUtils'
 import { InvokeOutput, OutputKind, sanitizePath } from './toolShared'
 import { split } from 'shlex'
+import path from 'path'
+import * as vscode from 'vscode'
+import { isInDirectory } from '../../shared/filesystemUtilities'
 
 export enum CommandCategory {
     ReadOnly,
@@ -215,6 +218,27 @@ export class ExecuteBash {
                         return { requiresAcceptance: true, warning: highRiskCommandWarningMessage }
                 }
             }
+            for (const cmdArgs of allCommands) {
+                for (const arg of cmdArgs) {
+                    if (this.looksLikePath(arg)) {
+                        // If not absolute, resolve using workingDirectory if available.
+                        let fullPath = arg
+                        if (!path.isAbsolute(arg) && this.workingDirectory) {
+                            fullPath = path.join(this.workingDirectory, arg)
+                        }
+                        const workspaceFolders = vscode.workspace.workspaceFolders
+                        if (!workspaceFolders || workspaceFolders.length === 0) {
+                            return { requiresAcceptance: true }
+                        }
+                        const isInWorkspace = workspaceFolders.some((folder) =>
+                            isInDirectory(folder.uri.fsPath, fullPath)
+                        )
+                        if (!isInWorkspace) {
+                            return { requiresAcceptance: true }
+                        }
+                    }
+                }
+            }
             return { requiresAcceptance: false }
         } catch (error) {
             this.logger.warn(`Error while checking acceptance: ${(error as Error).message}`)
@@ -329,5 +353,9 @@ export class ExecuteBash {
     public queueDescription(updates: Writable): void {
         updates.write('```shell\n' + this.command + '\n```')
         updates.end()
+    }
+
+    private looksLikePath(arg: string): boolean {
+        return arg.startsWith('/') || arg.startsWith('./') || arg.startsWith('../')
     }
 }

--- a/packages/core/src/codewhispererChat/tools/fsRead.ts
+++ b/packages/core/src/codewhispererChat/tools/fsRead.ts
@@ -5,7 +5,8 @@
 import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger/logger'
 import fs from '../../shared/fs/fs'
-import { InvokeOutput, maxToolResponseSize, OutputKind, sanitizePath } from './toolShared'
+import { InvokeOutput, maxToolResponseSize, OutputKind, sanitizePath, CommandValidation } from './toolShared'
+import { isInDirectory } from '../../shared/filesystemUtilities'
 import { Writable } from 'stream'
 import path from 'path'
 
@@ -66,6 +67,18 @@ export class FsRead {
             updates.write('all lines')
         }
         updates.end()
+    }
+
+    public requiresAcceptance(): CommandValidation {
+        const workspaceFolders = vscode.workspace.workspaceFolders
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            return { requiresAcceptance: true }
+        }
+        const isInWorkspace = workspaceFolders.some((folder) => isInDirectory(folder.uri.fsPath, this.fsPath))
+        if (!isInWorkspace) {
+            return { requiresAcceptance: true }
+        }
+        return { requiresAcceptance: false }
     }
 
     public async invoke(updates?: Writable): Promise<InvokeOutput> {

--- a/packages/core/src/codewhispererChat/tools/listDirectory.ts
+++ b/packages/core/src/codewhispererChat/tools/listDirectory.ts
@@ -6,7 +6,8 @@ import * as vscode from 'vscode'
 import { getLogger } from '../../shared/logger/logger'
 import { readDirectoryRecursively } from '../../shared/utilities/workspaceUtils'
 import fs from '../../shared/fs/fs'
-import { InvokeOutput, OutputKind, sanitizePath } from './toolShared'
+import { InvokeOutput, OutputKind, sanitizePath, CommandValidation } from './toolShared'
+import { isInDirectory } from '../../shared/filesystemUtilities'
 import { Writable } from 'stream'
 import path from 'path'
 
@@ -59,6 +60,18 @@ export class ListDirectory {
             updates.write(`Listing directory: ${fileName} limited to ${this.maxDepth} subfolder ${level}`)
         }
         updates.end()
+    }
+
+    public requiresAcceptance(): CommandValidation {
+        const workspaceFolders = vscode.workspace.workspaceFolders
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            return { requiresAcceptance: true }
+        }
+        const isInWorkspace = workspaceFolders.some((folder) => isInDirectory(folder.uri.fsPath, this.fsPath))
+        if (!isInWorkspace) {
+            return { requiresAcceptance: true }
+        }
+        return { requiresAcceptance: false }
     }
 
     public async invoke(updates?: Writable): Promise<InvokeOutput> {

--- a/packages/core/src/codewhispererChat/tools/toolShared.ts
+++ b/packages/core/src/codewhispererChat/tools/toolShared.ts
@@ -33,3 +33,8 @@ export function sanitizePath(inputPath: string): string {
     }
     return sanitized
 }
+
+export interface CommandValidation {
+    requiresAcceptance: boolean
+    warning?: string
+}

--- a/packages/core/src/codewhispererChat/tools/toolUtils.ts
+++ b/packages/core/src/codewhispererChat/tools/toolUtils.ts
@@ -40,13 +40,13 @@ export class ToolUtils {
     static requiresAcceptance(tool: Tool): CommandValidation {
         switch (tool.type) {
             case ToolType.FsRead:
-                return { requiresAcceptance: false }
+                return tool.tool.requiresAcceptance()
             case ToolType.FsWrite:
                 return { requiresAcceptance: false }
             case ToolType.ExecuteBash:
                 return tool.tool.requiresAcceptance()
             case ToolType.ListDirectory:
-                return { requiresAcceptance: false }
+                return tool.tool.requiresAcceptance()
         }
     }
 

--- a/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/fsRead.test.ts
@@ -6,12 +6,18 @@ import assert from 'assert'
 import { FsRead } from '../../../codewhispererChat/tools/fsRead'
 import { TestFolder } from '../../testUtil'
 import path from 'path'
+import sinon from 'sinon'
+import * as vscode from 'vscode'
 
 describe('FsRead Tool', () => {
     let testFolder: TestFolder
 
     before(async () => {
         testFolder = await TestFolder.create()
+    })
+
+    afterEach(() => {
+        sinon.restore()
     })
 
     it('throws if path is empty', async () => {
@@ -76,5 +82,33 @@ describe('FsRead Tool', () => {
         const result = await fsRead.invoke(process.stdout)
         assert.strictEqual(result.output.kind, 'text')
         assert.strictEqual(result.output.content, '')
+    })
+
+    it('should require acceptance if fsPath is outside the workspace', () => {
+        const workspaceStub = sinon
+            .stub(vscode.workspace, 'workspaceFolders')
+            .value([{ uri: { fsPath: '/workspace/folder' } } as any])
+        const fsRead = new FsRead({ path: '/not/in/workspace/file.txt' })
+        const result = fsRead.requiresAcceptance()
+        assert.equal(
+            result.requiresAcceptance,
+            true,
+            'Expected requiresAcceptance to be true for a path outside the workspace'
+        )
+        workspaceStub.restore()
+    })
+
+    it('should not require acceptance if fsPath is inside the workspace', () => {
+        const workspaceStub = sinon
+            .stub(vscode.workspace, 'workspaceFolders')
+            .value([{ uri: { fsPath: '/workspace/folder' } } as any])
+        const fsRead = new FsRead({ path: '/workspace/folder/file.txt' })
+        const result = fsRead.requiresAcceptance()
+        assert.equal(
+            result.requiresAcceptance,
+            false,
+            'Expected requiresAcceptance to be false for a path inside the workspace'
+        )
+        workspaceStub.restore()
     })
 })

--- a/packages/core/src/test/codewhispererChat/tools/listDirectory.test.ts
+++ b/packages/core/src/test/codewhispererChat/tools/listDirectory.test.ts
@@ -6,12 +6,18 @@ import assert from 'assert'
 import { ListDirectory } from '../../../codewhispererChat/tools/listDirectory'
 import { TestFolder } from '../../testUtil'
 import path from 'path'
+import sinon from 'sinon'
+import * as vscode from 'vscode'
 
 describe('ListDirectory Tool', () => {
     let testFolder: TestFolder
 
     before(async () => {
         testFolder = await TestFolder.create()
+    })
+
+    afterEach(() => {
+        sinon.restore()
     })
 
     it('throws if path is empty', async () => {
@@ -85,5 +91,33 @@ describe('ListDirectory Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         assert.ok(result.output.content.length > 0)
+    })
+
+    it('should require acceptance if fsPath is outside the workspace', () => {
+        const workspaceStub = sinon
+            .stub(vscode.workspace, 'workspaceFolders')
+            .value([{ uri: { fsPath: '/workspace/folder' } } as any])
+        const listDir = new ListDirectory({ path: '/not/in/workspace/dir', maxDepth: 0 })
+        const result = listDir.requiresAcceptance()
+        assert.equal(
+            result.requiresAcceptance,
+            true,
+            'Expected requiresAcceptance to be true for a path outside the workspace'
+        )
+        workspaceStub.restore()
+    })
+
+    it('should not require acceptance if fsPath is inside the workspace', () => {
+        const workspaceStub = sinon
+            .stub(vscode.workspace, 'workspaceFolders')
+            .value([{ uri: { fsPath: '/workspace/folder' } } as any])
+        const listDir = new ListDirectory({ path: '/workspace/folder/mydir', maxDepth: 0 })
+        const result = listDir.requiresAcceptance()
+        assert.equal(
+            result.requiresAcceptance,
+            false,
+            'Expected requiresAcceptance to be false for a path inside the workspace'
+        )
+        workspaceStub.restore()
     })
 })


### PR DESCRIPTION
## Problem
Should notice customer when tools accessing files/dirs outside of workspace

## Solution
Add validation step when accessing files/dirs outside of workspace using fsRead or listDirectories tools.

## Tests
Tests both tools, verified button shows up and workflow continues to finish after "accept"

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
